### PR TITLE
Default enableCertManager to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump upstream Kueue chart from `v0.14.1` to `v0.17.3`.
+- Default `enableCertManager` to `true` so Giant Swarm clusters use the
+  cert-manager that ships in the standard workload-cluster bundle without any
+  user configuration. Set to `false` on clusters without cert-manager.
+- Set `internalCertManagement.enable: false` automatically when
+  `enableCertManager: true` so the visibility server consumes the
+  cert-manager-issued certs instead of trying to self-sign into the read-only
+  secret mount (refs kubernetes-sigs/kueue#11133).
 - Switch `managerConfig` to `config.kueue.x-k8s.io/v1beta2`.
 - Add `ray.io/rayservice` to the default integration frameworks.
 - Add `certManager.issuerRef` to allow reusing an existing cert-manager `Issuer`/`ClusterIssuer`.

--- a/helm/kueue/values.yaml
+++ b/helm/kueue/values.yaml
@@ -8,8 +8,11 @@ nameOverride: ""
 fullnameOverride: ""
 # -- Enable Prometheus
 enablePrometheus: false
-# -- Enable x509 automated certificate management using cert-manager (cert-manager.io)
-enableCertManager: false
+# -- Enable x509 automated certificate management using cert-manager (cert-manager.io).
+# Defaults to true on Giant Swarm because cert-manager is part of the standard
+# workload-cluster bundle. Set to false on clusters that do not run cert-manager;
+# Kueue will fall back to its built-in self-signed cert management.
+enableCertManager: true
 certManager:
   # -- Override the default self-signed cert-manager issuer reference. When set, the chart skips creating its own Issuer and uses this reference for webhook, metrics, and visibility certificates. The referenced issuer must provide the CA data required by Kueue's cert-manager integration.
   issuerRef: {}


### PR DESCRIPTION
Giant Swarm workload clusters ship with cert-manager in the standard bundle, so the default install of this chart can rely on it. This removes the need for customers to opt in via a userConfig configmap and avoids the previous gotcha where enabling cert-manager on v0.17.x without setting internalCertManagement.enable=false caused the visibility server to crash.

Clusters that do not run cert-manager can still disable it explicitly.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
